### PR TITLE
Fixed #16 Liblouis fails to initialize when there's a space in the path

### DIFF
--- a/src/main/java/org/liblouis/Louis.java
+++ b/src/main/java/org/liblouis/Louis.java
@@ -22,6 +22,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.SimpleFileVisitor;
 import java.util.ArrayList;
@@ -420,7 +421,7 @@ public class Louis {
 		try {
 			if (!"file".equals(url.getProtocol()))
 				throw new RuntimeException("expected file URL");
-			return new File(new URI("file", url.getPath(), null));
+			return Paths.get(url.toURI()).toFile();
 		} catch (URISyntaxException e) {
 			throw new RuntimeException(e); // should not happen
 		}


### PR DESCRIPTION
Unfortunately this only fixes the problem of a space in the path (which shows up as '%20' in the file url and was not decoded back in the previous version, but leaves the other issues related to listResources() and table paths open... 